### PR TITLE
Escape % for clang support

### DIFF
--- a/include/OptiXToolkit/Memory/DeviceRingBuffer.h
+++ b/include/OptiXToolkit/Memory/DeviceRingBuffer.h
@@ -45,7 +45,7 @@ const unsigned int       WARP_SIZE = 32;
 __forceinline__ __device__ unsigned int getLaneId()
 {
     unsigned ret;
-    asm volatile( "mov.u32 %0, %laneid;" : "=r"( ret ) );
+    asm volatile( "mov.u32 %0, %%laneid;" : "=r"( ret ) );
     return ret;
 }
 #endif


### PR DESCRIPTION
Hello,

I get the following error when I try to include this project on some cuda compiled by clang++ 14:

```
optix-toolkit/Memory/include/OptiXToolkit/Memory/DeviceRingBuffer.h:48:34: error: invalid % escape in inline assembly string
    asm volatile( "mov.u32 %0, %laneid;" : "=r"( ret ) );
                  ~~~~~~~~~~~~~~~^~~~~~~
```

This patch escapes `%laneid` so that it compiles with nvcc and clang++.